### PR TITLE
Fix loading profile data

### DIFF
--- a/src/nostr/core.tsx
+++ b/src/nostr/core.tsx
@@ -222,7 +222,6 @@ export function useNostrEvents({
 
     sub.on("event", (event: NostrEvent) => {
       log(debug, "info", `⬇️ nostr (${relay.url}): Received event:`, event);
-
       onEventCallback?.(event);
       setEvents((_events) => {
         const newEvents = [event, ..._events];

--- a/src/nostr/useProfile.tsx
+++ b/src/nostr/useProfile.tsx
@@ -53,7 +53,6 @@ function useProfileQueue({ pubkey }: { pubkey: string }) {
       return arr;
     });
   }, [pubkey, setQueuedPubkeys, alreadyRequested, requestedPubkeys]);
-
   return {
     pubkeysToFetch: isReadyToFetch ? queuedPubkeys : [],
   };
@@ -66,26 +65,17 @@ export function useProfile({
   pubkey: string;
   enabled?: boolean;
 }) {
-  const [, setRequestedPubkeys] = useAtom(requestedPubkeysAtom);
   const { pubkeysToFetch } = useProfileQueue({ pubkey });
   const enabled = _enabled && !!pubkeysToFetch.length;
 
   const [fetchedProfiles, setFetchedProfiles] = useAtom(fetchedProfilesAtom);
 
-  const { onEvent, onSubscribe, isLoading, onDone } = useNostrEvents({
+  const { onEvent, isLoading, onDone } = useNostrEvents({
     filter: {
       kinds: [0],
       authors: pubkeysToFetch,
     },
     enabled,
-  });
-
-  onSubscribe(() => {
-    // Reset list
-    // (We've already opened a subscription to these pubkeys now)
-    setRequestedPubkeys((_pubkeys) => {
-      return [..._pubkeys, ...pubkeysToFetch].filter(uniqValues);
-    });
   });
 
   onEvent((rawMetadata) => {


### PR DESCRIPTION
This fixes loading of profile data (pictures, names, etc) across the app.

I believe the issue was that the `onSubscribe()` callback was removing pubkeys that we were still waiting on event responses for.

One issue that remains is that the responses are VERY slow, sometimes taking over a minute to start pouring in. I'm not sure if this is related to my own local setup or if it's something badly configured in how we're requesting these events from relays but I'll save that for another time. 