### PR TITLE
[Bounty] Replace web clients URLs with NIP27 references 

### DIFF
--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,0 @@
-import { render, screen } from "@testing-library/react";
-import App from "./App";
-
-test("renders learn react link", () => {
-  render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
-});

--- a/src/lib/Editor.js
+++ b/src/lib/Editor.js
@@ -25,6 +25,7 @@ import {
   sign,
   dateToUnix,
   useNostr,
+  NIP27URLReplace,
 } from "../nostr";
 import EventPreview from "./EventPreview";
 import Event from "./Event";
@@ -108,7 +109,7 @@ export default function MyEditor({ event }) {
   }, [title]);
 
   function onChange({ text }) {
-    setContent(text);
+    setContent(NIP27URLReplace(text));
   }
 
   async function onPublish() {

--- a/src/lib/Markdown.js
+++ b/src/lib/Markdown.js
@@ -1,6 +1,6 @@
 import { useMemo, useCallback } from "react";
 import { Link } from "react-router-dom";
-import ReactMarkdown from "react-markdown";
+import ReactMarkdown, { uriTransformer } from "react-markdown";
 import remarkGfm from "remark-gfm";
 import remarkMath from "remark-math";
 import remarkToc from "remark-toc";
@@ -276,6 +276,16 @@ function transformText(ps, tags) {
   return fragments;
 }
 
+function nostrUriTransformer(uri) {
+  const nostrProtocol = 'nostr:';
+
+  if (uri.startsWith(nostrProtocol)) {
+    return uri;
+  } else {
+    return uriTransformer(uri);
+  }
+}
+
 export default function Markdown({ tags = [], content }) {
   const components = useMemo(() => {
     return {
@@ -379,6 +389,7 @@ export default function Markdown({ tags = [], content }) {
       components={components}
       remarkPlugins={[replaceLinkHrefs, remarkGfm, remarkToc, remarkMath]}
       rehypePlugins={[rehypeRaw, rehypeKatex]}
+      transformLinkUri={nostrUriTransformer}
     >
       {content}
     </ReactMarkdown>

--- a/src/nostr/utils.test.ts
+++ b/src/nostr/utils.test.ts
@@ -1,0 +1,45 @@
+import {NIP27URLReplace} from "./utils";
+
+test('NIP27URLReplace links with npubs identifies', () => {
+    const input = "Sample text with url https://snort.social/p/npub1utx00neqgqln72j22kej3ux7803c2k986henvvha4thuwfkper4s7r50e8."
+    const expected_ouput = "Sample text with url nostr:npub1utx00neqgqln72j22kej3ux7803c2k986henvvha4thuwfkper4s7r50e8."
+    expect(NIP27URLReplace(input)).toBe(expected_ouput);
+});
+
+test('NIP27URLReplace links with note identifiers', () => {
+    const input = "Another sample text with [url](https://primal.net/thread/note1gc78tn2z9jyyav4lrwed8hl2xz2nggqsxr2setg3gqda0dlzwk6q99skts)."
+    const expected_ouput = "Another sample text with [url](nostr:note1gc78tn2z9jyyav4lrwed8hl2xz2nggqsxr2setg3gqda0dlzwk6q99skts)."
+    expect(NIP27URLReplace(input)).toBe(expected_ouput);
+});
+
+test('NIP27URLReplace links with nevent identifiers', () => {
+    const input = "Example https://coracle.social/nevent1qqsxgxcsq5vevy4wdty5z5v88nhwp2fc5qgl0ws5rmamn6z72hwv3qcpyfmhxue69uhkummnw3ez6an9wf5kv6t9vsh8wetvd3hhyer9wghxuet5qk6c9q?random_parameter=true"
+    const expected_ouput = "Example nostr:nevent1qqsxgxcsq5vevy4wdty5z5v88nhwp2fc5qgl0ws5rmamn6z72hwv3qcpyfmhxue69uhkummnw3ez6an9wf5kv6t9vsh8wetvd3hhyer9wghxuet5qk6c9q"
+    expect(NIP27URLReplace(input)).toBe(expected_ouput);
+});
+
+test('NIP27URLReplace links with nprofile identifiers', () => {
+    const input = "Nprofile url https://example.com/path/to/nprofile1234567890123456789012345678901234?param1=value1&param2=value2."
+    const expected_ouput = "Nprofile url nostr:nprofile1234567890123456789012345678901234."
+
+    expect(NIP27URLReplace(input)).toBe(expected_ouput);
+})
+
+test('NIP27URLReplace links with nrelay nevent identifiers', () => {
+    const input = "Nrelay url https://example.com/nrelay1asdf2ddd3."
+    const expected_ouput = "Nrelay url nostr:nrelay1asdf2ddd3."
+
+    expect(NIP27URLReplace(input)).toBe(expected_ouput);
+})
+
+test('NIP27URLReplace links with naddr naddr identifiers', () => {
+    const input = "Naddr url https://example.com/naddr1qqsxgxcsq5vevy4wdty5z5v88nhwp2fc5qgl0ws5rmamn6z72hwv3qcpyfmhxue69uhkummnw3ez6an9wf5kv6t9vsh8wetvd3hhyer9wghxuet5qk6c9q?param1=value1."
+    const expected_ouput = "Naddr url nostr:naddr1qqsxgxcsq5vevy4wdty5z5v88nhwp2fc5qgl0ws5rmamn6z72hwv3qcpyfmhxue69uhkummnw3ez6an9wf5kv6t9vsh8wetvd3hhyer9wghxuet5qk6c9q."
+    expect(NIP27URLReplace(input)).toBe(expected_ouput);
+})
+
+test('NIP27URLReplace links with edge-case URLs (ports, ipv6, hash fragment)', () => {
+    const input =  "url with a port number: http://example.com:8080/nprofile0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef?param=value&foo=bar. This url has an IPv6 address: http://[2001:0db8:85a3:0000:0000:8a2e:0370:7334]/nevent0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef. This url has a hash fragment https://example.com/note1234567890123456789012345678901234#sectionofmarkdowndocument."
+    const expected_ouput = "url with a port number: nostr:nprofile0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef. This url has an IPv6 address: nostr:nevent0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef. This url has a hash fragment nostr:note1234567890123456789012345678901234."
+    expect(NIP27URLReplace(input)).toBe(expected_ouput);
+})

--- a/src/nostr/utils.ts
+++ b/src/nostr/utils.ts
@@ -55,3 +55,29 @@ export function normalizeURL(url: string): string {
   p.hash = "";
   return p.toString();
 }
+
+export function NIP27URLReplace(content: string) {
+  // Replaces any website URL if they contain any NOSTR identifier (NIP-19) with a NOSTR text note reference (NIP-27)
+  // Reference:
+  //  * NIP-27 text note references: https://github.com/nostr-protocol/nips/blob/master/27.md
+  //  * NIP-19 identifiers: https://github.com/nostr-protocol/nips/blob/master/19.md
+  //  * NIP-19 identifiers size table: https://gist.github.com/LouisSaberhagen/f31c0f7869ab4b5c1844aff59873ef41
+
+  const urlPattern = /(https?:\/\/[^\s<]+[^<.,:;"')\]\s])/gi;
+  
+  const nPubPattern = /npub[0-9a-zA-Z]{32,}/g; // npub + 32 bytes
+  const notePattern = /note[0-9a-zA-Z]{32,}/g; // note + 32 bytes
+  const nProfilePattern = /nprofile[0-9a-zA-Z]{32,}/g; // nprofile + 34 bytes 
+  const nEventPattern = /nevent[0-9a-zA-Z]{32,}/g; // nevent + 34 bytes
+  const nRelayPattern = /nrelay[0-9a-zA-Z]{3,}/g; // nrelay + 3 bytes 
+  const nAddrPattern = /naddr[0-9a-zA-Z]{42,}/g; // naddr + 42 bytes
+
+  return content.replace(urlPattern, (url) => {
+    const match = url.match(nPubPattern) ?? url.match(notePattern) ?? url.match(nProfilePattern) ?? url.match(nEventPattern) ?? url.match(nRelayPattern) ?? url.match(nAddrPattern);
+    if (match) {
+       return 'nostr:' + match[0];
+    } else {
+      return url;
+    }
+  });
+}


### PR DESCRIPTION
I submit an alternative solution for the bounty in [nostrbounties](https://nostrbounties.com/b/naddr1qq9rzd3cxymrqvpjxsmsygrl54h466tz4v0re4pyuavvxqptsejl0vxcmnhfl60z3rth2xkpjspsgqqqw4rsnplnlx)

- [x]  It works **"when someone pastes a link"** and not until they submit the article.
- [x] NIP-19 Spec Compliant
- [x] Tests included
- [x] Extended ReactMarkdown to support "NOSTR:" links


https://user-images.githubusercontent.com/115233399/232646041-827f4b54-362d-45b3-be7b-ce2955600d67.mp4

